### PR TITLE
Integrate with kepler action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,13 +47,33 @@ jobs:
 
   unitpreOS:
     strategy:
+      fail-fast: false
       matrix:
       # us-east-2
       # Ubuntu 20.04 AMI is ami-0e4d0bb9670ea8db0
       # ubuntu 22.04 AMI is ami-05fb0b8c1424f266b 
       # RHEL 9       AMI is ami-078cbc4c2d057c244
-        AMI_ID: [ami-0e4d0bb9670ea8db0,ami-05fb0b8c1424f266b,ami-078cbc4c2d057c244]
+        AMI_ID: [ami-0e4d0bb9670ea8db0,ami-078cbc4c2d057c244]
     uses: ./.github/workflows/ci_unit.yml
+    secrets:
+        AWS_REGION: ${{ secrets.AWS_REGION }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        GH_SELF_HOSTED_RUNNER_TOKEN: ${{ secrets.GH_SELF_HOSTED_RUNNER_TOKEN }}
+        AWS_SECURITY_GROUP_ID: ${{ secrets.AWS_SECURITY_GROUP_ID }}
+        AMI_ID:  ${{matrix.AMI_ID}}
+
+  integration:
+    needs: [unitpreOS]
+    strategy:
+      fail-fast: false
+      matrix:
+      # us-east-2
+      # Ubuntu 20.04 AMI is ami-0e4d0bb9670ea8db0
+      # ubuntu 22.04 AMI is ami-05fb0b8c1424f266b 
+      # RHEL 9       AMI is ami-078cbc4c2d057c244
+        AMI_ID: [ami-05fb0b8c1424f266b]
+    uses: ./.github/workflows/ci_integration.yml
     secrets:
         AWS_REGION: ${{ secrets.AWS_REGION }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -44,7 +44,7 @@ jobs:
             security_group_id: ${{ secrets.AWS_SECURITY_GROUP_ID }}
             github_repo: ${{ github.repository }}
             ami_id: ${{ secrets.AMI_ID }}
-            instance_type: "t2.micro"
+            instance_type: "i3.metal"
             create_s3_bucket: "false"
             spot_instance_only: "true"
 
@@ -63,6 +63,39 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install Docker
+        id: docker
+        run: |
+            # Add Docker's official GPG key:
+            apt-get update -y
+            apt-get install ca-certificates curl gnupg -y
+            install -m 0755 -d /etc/apt/keyrings
+            curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+            chmod a+r /etc/apt/keyrings/docker.gpg
+            # Add the repository to Apt sources:
+            echo \
+              "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+              $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+              tee /etc/apt/sources.list.d/docker.list > /dev/null
+            apt-get update -y
+            apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
+            docker info
+
+      - name: install make and tooling for libbpf
+        id: dependency
+        run: |
+            apt-get install -y binutils-dev build-essential 
+            apt-get install -y pkg-config
+            env
+
+      - name: use Kepler action to deploy cluster
+        uses: sustainable-computing-io/kepler-action@main
+        with:
+          ebpfprovider: libbpf
+          cluster_provider: kind
+          prometheus_enable: true
+          tekton_enable: true
+
       - name: Run Tests
         run: |
           export INSTANCE_ID="${{ needs.setup-runner.outputs.instance_id }}"
@@ -70,6 +103,8 @@ jobs:
           uname -a # or any other command
           cat /etc/os-release 
           cat /proc/cpuinfo
+          kind get kubeconfig --name=kind > /tmp/kubeconfig
+          kubectl get po --all-namespaces --kubeconfig=/tmp/kubeconfig
 
   destroy-runner:
     if: always()


### PR DESCRIPTION
try to integration with latest kepler-action with features below to provide a tekton based k8s cluster for kepler's CI for model server training and validation.
1. set up container run time as docker.
2. use kepler action to install header and libbpf
3. use kepler action to set k8s cluster as kind for now
4. set up prometheus
5. set up tekton

todo in other PRs:
- for redhat support will be refined in other PR, as local dev cluster and kepler action need to be refined.
- for docker and other basic tooling.... keep them for now, or maybe we should considering a self build image on aws?
- for other container runtime backend and podman... in the future
- some refine works in local dev cluster.
